### PR TITLE
InventoryCloseEvent triggering UIEvent every close

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.github.DebitCardz:mc-chestui-plus:1.0.4")
+    implementation("com.github.DebitCardz:mc-chestui-plus:1.0.5")
 }
 ```
 ### Maven
@@ -31,7 +31,7 @@ dependencies {
 <dependency>
     <groupId>com.github.DebitCardz</groupId>
     <artifactId>mc-chestui-plus</artifactId>
-    <version>1.0.4</version>
+    <version>1.0.5</version>
 </dependency>
 
 ```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ val githubActor = project.findProperty("gpr.user") as String? ?: System.getenv("
 val githubToken = project.findProperty("gpr.key") as String? ?: System.getenv("GITHUB_TOKEN")
 
 group = "me.tech"
-version = "1.0.4"
+version = "1.0.5"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/me/tech/mcchestui/GUI.kt
+++ b/src/main/kotlin/me/tech/mcchestui/GUI.kt
@@ -268,6 +268,10 @@ class GUI(
 
 	@EventHandler(priority = EventPriority.MONITOR)
 	internal fun onInventoryClose(ev: InventoryCloseEvent) {
+		if(ev.inventory != inventory) {
+			return
+		}
+
 		onCloseInventory?.let { uiEvent ->
 			uiEvent(ev, ev.player)
 		}
@@ -277,7 +281,7 @@ class GUI(
 			return
 		}
 
-		if(ev.inventory != inventory || ev.inventory.viewers.size > 1) {
+		if(ev.inventory.viewers.size > 1) {
 			return
 		}
 


### PR DESCRIPTION
Because it was never checked which inventory was being closed this would fire for all inventories regardless of if the correct inventory was being closed.