### PR TITLE
refactor: retire GUIProp

### DIFF
--- a/src/main/kotlin/me/tech/mcchestui/GUIHelper.kt
+++ b/src/main/kotlin/me/tech/mcchestui/GUIHelper.kt
@@ -42,13 +42,6 @@ fun HumanEntity.openGUI(gui: GUI) {
 }
 
 /**
- * Component placed inside of a [GUI.Slot]
- * that practically represents a [GUI.Slot] builder.
- * Props are usually passed from function parameters if needed.
- */
-typealias GUIComponent = GUI.Slot.() -> Unit
-
-/**
  * Event when an [ItemStack] interaction is preformed with a [GUI].
  */
 internal typealias GUIItemPlaceEvent = InventoryClickEvent.(player: Player, item: ItemStack, slot: Int) -> Boolean

--- a/src/main/kotlin/me/tech/mcchestui/GUIHelper.kt
+++ b/src/main/kotlin/me/tech/mcchestui/GUIHelper.kt
@@ -42,11 +42,11 @@ fun HumanEntity.openGUI(gui: GUI) {
 }
 
 /**
- * Prop for a [GUI] that is placed into a
- * [GUI.Slot] that usually has data passed into it
- * through a function.
+ * Component placed inside of a [GUI.Slot]
+ * that practically represents a [GUI.Slot] builder.
+ * Props are usually passed from function parameters if needed.
  */
-typealias GUIProp = GUI.Slot.() -> Unit
+typealias GUIComponent = GUI.Slot.() -> Unit
 
 /**
  * Event when an [ItemStack] interaction is preformed with a [GUI].


### PR DESCRIPTION
the old name of `GUIProp` was simply not representative of what this typealias is actually supposed to do.