### PR TITLE
Implement GUI templating

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.github.DebitCardz:mc-chestui-plus:1.1.0")
+    implementation("com.github.DebitCardz:mc-chestui-plus:1.2.0")
 }
 ```
 ### Maven
@@ -34,7 +34,7 @@ dependencies {
 <dependency>
     <groupId>com.github.DebitCardz</groupId>
     <artifactId>mc-chestui-plus</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
 </dependency>
 
 ```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm") version "1.9.0"
+    kotlin("jvm") version "1.9.20"
 
     id("maven-publish")
 }
@@ -8,7 +8,7 @@ val githubActor = project.findProperty("gpr.user") as String? ?: System.getenv("
 val githubToken = project.findProperty("gpr.key") as String? ?: System.getenv("GITHUB_TOKEN")
 
 group = "me.tech"
-version = "1.1.0"
+version = "1.2.0"
 
 repositories {
     mavenCentral()
@@ -23,8 +23,6 @@ dependencies {
 }
 
 java {
-    toolchain.languageVersion.set(JavaLanguageVersion.of(17))
-
     withJavadocJar()
     withSourcesJar()
 }
@@ -44,6 +42,7 @@ publishing {
 
     publications {
         register<MavenPublication>("gpr") {
+            artifactId = "mc-chestui-plus"
             from(components["java"])
         }
     }

--- a/src/main/kotlin/me/tech/mcchestui/GUI.kt
+++ b/src/main/kotlin/me/tech/mcchestui/GUI.kt
@@ -41,6 +41,17 @@ fun toSlot(x: Int, y: Int, type: GUIType): Int {
 }
 fun fromSlot(s: Int, type: GUIType) = Pair(s % type.slotsPerRow, s / type.slotsPerRow)
 
+/**
+ * Construct a [GUI.Slot] to be placed in a [GUI].
+ * This is primarily a utility method.
+ *
+ * @param builder [GUI.Slot] builder.
+ * @return constructed [GUI.Slot].
+ */
+fun GUI.guiSlot(builder: GUI.Slot.() -> Unit): GUI.Slot {
+	return Slot().apply(builder)
+}
+
 class GUI(
 	plugin: JavaPlugin,
 	val title: Component,
@@ -118,7 +129,7 @@ class GUI(
 	/**
 	 * Chars mapped to Slot Builders for GUI templating.
 	 */
-	internal var templateItems = mutableMapOf<Char, Slot.() -> Unit>()
+	internal var templateSlots = mutableMapOf<Char, Slot>()
 
 	private val guiListener = GUIListener(this)
 
@@ -133,6 +144,10 @@ class GUI(
 			.registerEvents(guiListener, plugin)
 	}
 
+	/**
+	 * Structure of a slot item in a [GUI].
+	 * Defines displayed [GUIItem] and click actions.
+	 */
 	inner class Slot {
 		var item: GUIItem? = null
 		var allowPickup: Boolean = false
@@ -154,17 +169,37 @@ class GUI(
 	 * Set the item in a specific GUI slot.
 	 *
 	 * @param i slot index
-	 * @param builder slot builder
+	 * @param slot slot
 	 */
-	fun slot(i: Int, builder: Slot.() -> Unit) {
+	fun slot(i: Int, slot: Slot) {
 		if(i > bukkitInventory.size) {
 			return
 		}
 
-		val slot = Slot().apply(builder)
 		bukkitInventory.setItem(i, slot.item?.stack)
 
 		slots[i] = slot
+	}
+
+	/**
+	 * Set the item in a specific GUI slot.
+	 *
+	 * @param i slot index
+	 * @param builder slot builder
+	 */
+	fun slot(i: Int, builder: Slot.() -> Unit) {
+		slot(i, Slot().apply(builder))
+	}
+
+	/**
+	 * Set the item in a specific GUI slot.
+	 *
+	 * @param x x-coordinate of the slot
+	 * @param y y-coordinate of the slot
+	 * @param slot slot
+	 */
+	fun slot(x: Int, y: Int, slot: Slot) {
+		slot(toSlot(x, y, type), slot)
 	}
 
 	/**

--- a/src/main/kotlin/me/tech/mcchestui/GUI.kt
+++ b/src/main/kotlin/me/tech/mcchestui/GUI.kt
@@ -115,6 +115,11 @@ class GUI(
 
 	internal var slots = arrayOfNulls<Slot>(type.slotsPerRow * type.rows)
 
+	/**
+	 * Chars mapped to Slot Builders for GUI templating.
+	 */
+	internal var templateItems = mutableMapOf<Char, Slot.() -> Unit>()
+
 	private val guiListener = GUIListener(this)
 
 	/**

--- a/src/main/kotlin/me/tech/mcchestui/GUI.kt
+++ b/src/main/kotlin/me/tech/mcchestui/GUI.kt
@@ -76,7 +76,7 @@ class GUI(
 
 	/**
 	 * Allow for [ItemStack] not registered in slots to
-	 * be taken from the [GUI].]
+	 * be taken from the [GUI].
 	 */
 	var allowItemPickup: Boolean = false
 

--- a/src/main/kotlin/me/tech/mcchestui/GUIHelper.kt
+++ b/src/main/kotlin/me/tech/mcchestui/GUIHelper.kt
@@ -6,7 +6,6 @@ import org.bukkit.entity.Player
 import org.bukkit.event.inventory.InventoryClickEvent
 import org.bukkit.event.inventory.InventoryCloseEvent
 import org.bukkit.event.inventory.InventoryDragEvent
-import org.bukkit.event.inventory.InventoryInteractEvent
 import org.bukkit.inventory.ItemStack
 import org.bukkit.plugin.java.JavaPlugin
 

--- a/src/main/kotlin/me/tech/mcchestui/GUITemplate.kt
+++ b/src/main/kotlin/me/tech/mcchestui/GUITemplate.kt
@@ -1,0 +1,83 @@
+package me.tech.mcchestui
+
+/**
+ * Representing the structure of the GUI Template.
+ */
+data class GUITemplate(
+    var firstRow: String? = null,
+    var secondRow: String? = null,
+    var thirdRow: String? = null,
+    var fourthRow: String? = null,
+    var fifthRow: String? = null,
+    var sixthRow: String? = null,
+    var rows: String? = null
+) {
+    private val usingRows get() = rows != null
+
+    /**
+     * @return list of characters mapped to the row.
+     */
+    internal fun toMap(): Map<Int, List<Char>> {
+        if(usingRows) {
+            return rows
+                ?.split("\n")
+                ?.withIndex()
+                ?.associate { it.index + 1 to toCharList(it.value) }
+                ?: emptyMap()
+        } else {
+            return mapOf(
+                1 to toCharList(firstRow),
+                2 to toCharList(secondRow),
+                3 to toCharList(thirdRow),
+                4 to toCharList(fourthRow),
+                5 to toCharList(fifthRow),
+                6 to toCharList(sixthRow)
+            )
+        }
+    }
+
+    /**
+     * Automatically removes whitespace and maps [Char].
+     *
+     * @return list of each character
+     */
+    private fun toCharList(str: String?): List<Char> {
+        return str
+            ?.filterNot { it.isWhitespace() }
+            ?.map { it }
+            ?: return emptyList()
+    }
+}
+
+/**
+ * Define chars to be used for templating.
+ *
+ * @param char template character
+ * @param builder slot builder
+ */
+fun GUI.addTemplateSlot(char: Char, builder: GUI.Slot.() -> Unit) {
+    templateItems[char] = builder
+}
+
+/**
+ * Structure the template of the [GUI].
+ *
+ * @param builder template builder
+ */
+fun GUI.template(builder: GUITemplate.() -> Unit) {
+    val map = GUITemplate().apply(builder)
+        .toMap()
+
+    for((yIndex, chars) in map) {
+        if(chars.isEmpty()) {
+            continue
+        }
+
+        for((xIndex, char) in chars.withIndex()) {
+            val templateSlotBuilder = templateItems[char]
+                ?: continue
+
+            slot(xIndex + 1, yIndex, templateSlotBuilder)
+        }
+    }
+}

--- a/src/main/kotlin/me/tech/mcchestui/GUITemplate.kt
+++ b/src/main/kotlin/me/tech/mcchestui/GUITemplate.kt
@@ -56,7 +56,17 @@ data class GUITemplate(
  * @param builder slot builder
  */
 fun GUI.addTemplateSlot(char: Char, builder: GUI.Slot.() -> Unit) {
-    templateItems[char] = builder
+    templateSlots[char] = guiSlot(builder)
+}
+
+/**
+ * Define chars to be used for templating.
+ *
+ * @param char template character
+ * @param slot slot
+ */
+fun GUI.addTemplateSLot(char: Char, slot: GUI.Slot) {
+    templateSlots[char] = slot
 }
 
 /**
@@ -74,10 +84,10 @@ fun GUI.template(builder: GUITemplate.() -> Unit) {
         }
 
         for((xIndex, char) in chars.withIndex()) {
-            val templateSlotBuilder = templateItems[char]
+            val slot = templateSlots[char]
                 ?: continue
 
-            slot(xIndex + 1, yIndex, templateSlotBuilder)
+            slot(xIndex + 1, yIndex, slot)
         }
     }
 }


### PR DESCRIPTION
Templating code like this is completely valid.
```kt
gui(
    this,
    Component.empty(),
    GUIType.Chest(rows = 6)
) {
    template {
        addTemplateSlot('#') {
            item = item(Material.GRAY_STAINED_GLASS_PANE) {
                name = Component.empty()
            }
        }

        rows = """
            ${"#".repeat(9)}
            # # . . . . . #
            # . # . . . #
            # . . # . #
            # . . . #
            ${"#".repeat(9)}
        """.trimIndent()
    }
}
```
The implementation will treat templated strings such as `###` as `# # #` which helps with readability and allows for tricks like using `String#repeat` without worrying about proper spacing.
        